### PR TITLE
fix: project name input (lowercase & hyphens)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -64,6 +64,8 @@ async function runCLI() {
         message: '📝 Enter your project name:',
         validate: (input) =>
           input.trim() !== '' || 'Project name cannot be empty',
+        filter: (input) =>
+          input.trim().toLowerCase().replace(/\s+/g, '-'),
       },
     ]);
 


### PR DESCRIPTION
This PR enhances the project name prompt in **quickFrontend** by sanitizing the user input. The following improvements have been made:

- Converts the input to lowercase.
- Trims leading and trailing whitespace.
- Replaces all spaces with hyphens ("My Project" → "my-project").

These changes ensure consistent folder naming and prevent errors during project creation.

